### PR TITLE
- Modificati i file project.json delle due mini-app catalog e check o…

### DIFF
--- a/apps/catalog/project.json
+++ b/apps/catalog/project.json
@@ -49,7 +49,8 @@
       "defaultConfiguration": "development",
       "options": {
         "buildTarget": "catalog:build",
-        "hmr": true
+        "hmr": true,
+        "port": 4200
       },
       "configurations": {
         "development": {

--- a/apps/checkout/project.json
+++ b/apps/checkout/project.json
@@ -49,7 +49,8 @@
       "defaultConfiguration": "development",
       "options": {
         "buildTarget": "checkout:build",
-        "hmr": true
+        "hmr": true,
+        "port": 4201
       },
       "configurations": {
         "development": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "start": "nx serve",
     "build": "nx build",
-    "test": "nx test"
+    "test": "nx test",
+    "serve:all": "nx run-many --target=serve"
   },
   "private": true,
   "dependencies": {


### PR DESCRIPTION
- Modificati i file project.json delle due mini-app catalog e check out, in modo che non sia necessario indicare la loro porta in fase di avvio.

- Modificato il file di progetto package.json modificando la sezione script aggiungendo "serve:all": "nx run-many --target=serve" in modo che richiamando pnpm run serve-all verrà eseguito nx nel seguente modo "nx run-many" --target=server. Che significa run-many eseguire tutte le micro-app presenti (tutti i workspase di Nx) e --target=serve sul server web di sviluppo offero in questo caso da Webpack Dev essendo un'applicazione React.